### PR TITLE
refactor: extract inline Online Designer JS, add ESLint CI

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -1,0 +1,31 @@
+name: js-lint
+
+on:
+  pull_request:
+    paths:
+      - 'js/**'
+      - 'eslint.config.js'
+      - '.github/workflows/js-lint.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'js/**'
+      - 'eslint.config.js'
+      - '.github/workflows/js-lint.yml'
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # No lockfile/npm project for two lint-only dependencies - versions are
+      # pinned here instead. See design.md in
+      # openspec/changes/ontology-provider-extract-inline-js.
+      - run: npm install --no-save eslint@10.9.1 eslint-plugin-no-jquery@6.0.0
+
+      - run: npx eslint js/

--- a/.github/workflows/no-inline-script.yml
+++ b/.github/workflows/no-inline-script.yml
@@ -19,7 +19,16 @@ jobs:
 
       - name: Fail on inline <script> blocks in PHP
         run: |
-          if grep -rnE '<script(\s|>)' --include='*.php' --exclude-dir=tests --exclude-dir=vendor . | grep -v 'src='; then
-            echo "::error::Inline <script> block found in a PHP file - move the JS into a real .js file under js/ and load it via \$this->getUrl() instead (see openspec/changes/ontology-provider-extract-inline-js)."
+          # -z reads each file as one NUL-separated record (with (?s) making
+          # . match newlines) so a <script ...> tag whose attributes wrap
+          # onto a following line is still caught. The negative lookahead
+          # checks only the tag itself (up to its own closing >) for a src=
+          # attribute - a plain `grep -v 'src='` on the whole line would
+          # wrongly clear an inline script whose body just happens to
+          # contain the substring "src=" (e.g. `element.src = '...'`).
+          FILES=$(grep -rlPz --include='*.php' --exclude-dir=tests --exclude-dir=vendor '(?s)<script(?![^>]*\bsrc=)[\s>]' . || true)
+          if [ -n "$FILES" ]; then
+            echo "$FILES"
+            echo "::error::Inline <script> block found in a PHP file above. Move the JavaScript into a real .js file under js/ and load it via \$this->getUrl('js/<file>.js') plus <script src=\"...\"></script>, matching this module's existing js/online-designer.js pattern."
             exit 1
           fi

--- a/.github/workflows/no-inline-script.yml
+++ b/.github/workflows/no-inline-script.yml
@@ -1,0 +1,25 @@
+name: no-inline-script
+
+# Guards against a <script> block creeping back into PHP (the pattern
+# js-lint.yml's ESLint job can't see, since it's path-filtered to js/**).
+# Runs on every PR/push unconditionally rather than path-filtered, since a
+# reintroduced inline script could land in any .php file, not just ones
+# already known to have had one.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fail on inline <script> blocks in PHP
+        run: |
+          if grep -rnE '<script(\s|>)' --include='*.php' --exclude-dir=tests --exclude-dir=vendor . | grep -v 'src='; then
+            echo "::error::Inline <script> block found in a PHP file - move the JS into a real .js file under js/ and load it via \$this->getUrl() instead (see openspec/changes/ontology-provider-extract-inline-js)."
+            exit 1
+          fi

--- a/SimpleOntologyExternalModule.php
+++ b/SimpleOntologyExternalModule.php
@@ -256,14 +256,9 @@ class SimpleOntologyExternalModule extends AbstractExternalModule implements \On
             $categoryList .= "<option value='{$category}'>{$name}</option>\n";
         }
 
+        $onlineDesignerJsUrl = $this->getUrl('js/online-designer.js');
         $onlineDesignerHtml = <<<EOD
-<script type="text/javascript">
-  function SIMPLE_ontology_changed(service, category){
-    var newSelection = ('SIMPLE' == service) ? category : '';
-    $('#simple_ontology_category').val(newSelection);
-  }
-  
-</script>
+<script src="{$onlineDesignerJsUrl}"></script>
 <div style='margin-bottom:3px;'>
   Select Local Ontology to use:
 </div>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,27 @@
+const noJquery = require('eslint-plugin-no-jquery');
+
+// Scoped narrowly to the jQuery DOM-injection patterns that are this
+// repo's actual XSS threat model (see PR #5 on redcap_fhir_ontology_provider
+// and ontology-provider-security-audit task 2.5) - not a general style
+// linter.
+module.exports = [
+  {
+    files: ['js/**/*.js'],
+    languageOptions: {
+      globals: {
+        $: 'readonly',
+        jQuery: 'readonly',
+        update_ontology_selection: 'readonly',
+      },
+    },
+    plugins: {
+      'no-jquery': noJquery,
+    },
+    rules: {
+      'no-jquery/no-html': 'error',
+      'no-jquery/no-append-html': 'error',
+      'no-jquery/no-parse-html': 'error',
+      'no-jquery/no-parse-html-literal': 'error',
+    },
+  },
+];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,6 @@ module.exports = [
       globals: {
         $: 'readonly',
         jQuery: 'readonly',
-        update_ontology_selection: 'readonly',
       },
     },
     plugins: {

--- a/js/online-designer.js
+++ b/js/online-designer.js
@@ -1,0 +1,4 @@
+function SIMPLE_ontology_changed(service, category){
+  var newSelection = ('SIMPLE' == service) ? category : '';
+  $('#simple_ontology_category').val(newSelection);
+}

--- a/tests/SimpleOntologyExternalModuleTest.php
+++ b/tests/SimpleOntologyExternalModuleTest.php
@@ -263,4 +263,30 @@ final class SimpleOntologyExternalModuleTest extends TestCase
         $this->assertSame([], $hidden);
         $this->assertSame(1, \REDCap::$getDataDictionaryCallCount);
     }
+
+    // --- getOnlineDesignerSection() ---
+    // Regression coverage for the js/online-designer.js extraction: this
+    // method's heredoc was never exercised by any test before, so a broken
+    // interpolation or an inline <script> creeping back in would only have
+    // been caught by a manual browser check.
+
+    public function testOnlineDesignerSectionLoadsExtractedJsFileNotInlineScript(): void
+    {
+        $html = $this->module->getOnlineDesignerSection();
+
+        $this->assertStringContainsString('<script src="FAKE_MODULE_URL/js/online-designer.js"></script>', $html);
+        $this->assertStringNotContainsString('function SIMPLE_ontology_changed', $html);
+    }
+
+    public function testOnlineDesignerSectionListsConfiguredCategories(): void
+    {
+        $this->module->subSettings['site-category-list'] = [$this->siteCategory([
+            'site-category' => 'cat1',
+            'site-name' => 'Category One',
+        ])];
+
+        $html = $this->module->getOnlineDesignerSection();
+
+        $this->assertStringContainsString("<option value='cat1'>Category One</option>", $html);
+    }
 }

--- a/tests/support/RedcapClassFakes.php
+++ b/tests/support/RedcapClassFakes.php
@@ -24,6 +24,14 @@ namespace ExternalModules {
         {
             return $this->subSettings[$key] ?? [];
         }
+
+        /** Real getUrl() returns a webroot path plus a cache-busting
+         *  ?filemtime for a resource file - this fake just echoes the path
+         *  distinctively enough for tests to assert on. */
+        public function getUrl($path)
+        {
+            return 'FAKE_MODULE_URL/' . $path;
+        }
     }
 
     class ExternalModules {}


### PR DESCRIPTION
## Summary
- `getOnlineDesignerSection()` embedded its JavaScript directly inside a PHP heredoc string. Psalm's `--taint-analysis` (`security-scan.yml`) only sees PHP, so this JS was invisible to any scanner - a gap flagged as a follow-up in `ontology-provider-release-engineering`'s design.md but never actioned.
- Moves the `SIMPLE_ontology_changed()` function verbatim into `js/online-designer.js`, loaded via the existing `$this->getUrl()` + `<script src>` convention already used elsewhere in this workspace (`redcap_pedigree_editor`). No PHP variable was interpolated inside the script body, so this is a pure structural move - the surrounding HTML is unchanged.
- Adds a `js-lint.yml` CI job running ESLint with `eslint-plugin-no-jquery`, scoped to the jQuery DOM-injection rules (`no-html`, `no-append-html`, `no-parse-html`, `no-parse-html-literal`) - the same XSS pattern class PR #5 on `redcap_fhir_ontology_provider` fixed. No lockfile/npm project: versions pinned directly in the workflow for two lint-only dependencies.
- `redcap_fhir_ontology_provider` is out of scope here (three `<script>` blocks, more complex, still blocked on external PR #5) - tracked separately.

## Test plan
- [x] `php -l` clean
- [x] 15/15 existing unit tests still pass under `--network none`
- [x] `getUrl()`'s resource-URL mechanism confirmed by reading REDCap core source (a static-file URL, no auth) and by curling the deployed file directly (200, `text/javascript`, exact content)
- [x] ESLint config verified to actually catch the pattern it claims to: added a throwaway `.html(userInput)` call, confirmed the job fails, removed it, then confirmed the real extracted file lints clean
- [x] Deployed to a local REDCap 16.0.32 instance; manually confirmed in a browser that the Online Designer's ontology dropdown still loads and `online-designer.js` is served (Network tab / view-source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)