### PR TITLE
fix!: document the PHP 8.0 minimum and flag it as the breaking change it was

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 For a terser, automatically generated commit-by-commit version record, see [CHANGELOG.md](./CHANGELOG.md).
 
+## Requirements
+
+- PHP 8.0.0 or later
+- REDCap 8.8.1 or later, on External Module framework version 16 or later
+
 This redcap external module allows the definition of a custom set of 'ontologies' which can be used to provide
 autocomplete functionality for a text field. Ontologies can be defined at a site or project level, and a default value
 can be specified to be returned if no match is found. Since version 0.4, an option has been added to select to swap


### PR DESCRIPTION
commit edd2e40 ("chore: upgrade to EM framework version 16", PR #12) raised `php-version-min` from `5.4.0` to `8.0.0` but was titled as a plain `chore:`, so release-please never registered it as a breaking change - sites running PHP 5.4-7.4 can no longer install this module version, and that was never reflected in the version history. This was also never documented in the README at all until now.

Not rewriting `edd2e40`'s already-merged history - this commit's own `BREAKING CHANGE` footer is what makes the next release-please run correctly compute a major version bump for the pending release.

BREAKING CHANGE: php-version-min is 8.0.0 (raised from 5.4.0 in PR #12, "chore: upgrade to EM framework version 16"). Sites running PHP older than 8.0 cannot install or enable this module version.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>